### PR TITLE
First pass at using bluesky-widgets to generate thumbnails.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ area_detector_handlers >=0.0.8
 bluesky-widgets >=0.0.5
 event_model
 h5py
+matplotlib
 numpy
 passlib
 pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Pillow
 area_detector_handlers >=0.0.8
-bluesky-widgets
+bluesky-widgets >=0.0.5
 event_model
 h5py
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Pillow
 area_detector_handlers
+bluesky-widgets
 event_model
 h5py
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
-area_detector_handlers
+area_detector_handlers >=0.0.8
 bluesky-widgets
 event_model
 h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Pillow
 area_detector_handlers >=0.0.8
-bluesky-widgets >=0.0.5
+bluesky-widgets >=0.0.6b1
 event_model
 h5py
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Pillow
 area_detector_handlers >=0.0.8
 bluesky-widgets >=0.0.6b1
-event_model
+event_model >=1.17.1
 h5py
 matplotlib
 numpy

--- a/splash_ingest/handlers.py
+++ b/splash_ingest/handlers.py
@@ -21,3 +21,7 @@ class MultiKeyHDF5DatasetSliceHandler(HDF5DatasetSliceHandlerPureNumpy):
         # print(str(point_number))
         return dask.array.from_array(self._datasets[key])[start:stop][0, :, :] 
         # return self._datasets[key][start:stop][0, :, :]
+
+    def close(self):
+        # Do nothing.
+        pass

--- a/splash_ingest/handlers.py
+++ b/splash_ingest/handlers.py
@@ -21,9 +21,3 @@ class MultiKeyHDF5DatasetSliceHandler(HDF5DatasetSliceHandlerPureNumpy):
         # print(str(point_number))
         return dask.array.from_array(self._datasets[key])[start:stop][0, :, :] 
         # return self._datasets[key][start:stop][0, :, :]
-
-    def __del__(self):
-        # Explicitly do NOT close on __del__.
-        # This will be fixed upstream in the base class (in PR
-        # bluesky/area-detector-handlers#25) but for now we'll override it here.
-        pass

--- a/splash_ingest/handlers.py
+++ b/splash_ingest/handlers.py
@@ -22,6 +22,8 @@ class MultiKeyHDF5DatasetSliceHandler(HDF5DatasetSliceHandlerPureNumpy):
         return dask.array.from_array(self._datasets[key])[start:stop][0, :, :] 
         # return self._datasets[key][start:stop][0, :, :]
 
-    def close(self):
-        # Do nothing.
+    def __del__(self):
+        # Explicitly do NOT close on __del__.
+        # This will be fixed upstream in the base class (in PR
+        # bluesky/area-detector-handlers#25) but for now we'll override it here.
         pass

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -185,8 +185,8 @@ class MappedHD5Ingestor():
                             datum = hd5_resource.compose_datum(datum_kwargs={
                                     "key": encoded_key,
                                     "point_number": x})  # need kwargs for HDF5 datum
-                            # if logger.isEnabledFor(logging.DEBUG):
-                            #     logger.debug(f"run: {start_doc['uid']} Creating datum with uid: {datum['datum_id']}")
+                            if logger.isEnabledFor(logging.DEBUG):
+                                logger.debug(f"run: {start_doc['uid']} Creating datum with uid: {datum['datum_id']}")
                             document_cache('datum', datum)
                             yield 'datum', datum
                             event_data[encoded_key] = datum['datum_id']

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from typing import List
 
@@ -220,6 +221,7 @@ class MappedHD5Ingestor():
         model = SplashAutoImages()
         model.add_run(bluesky_run)
         view = HeadlessFigures(model.figures)
+        os.makedirs(Path(directory, uid), exist_ok=True)
         filenames = view.export_all(Path(directory, uid), format='png')
         print("WROTE", filenames)
 

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -289,7 +289,9 @@ def _log_and_auto_contrast(data):
     log_image = data - np.min(data) + 1.001
     log_image = np.log(log_image)
     log_image = 205*log_image/(np.max(log_image))
-    auto_contrast_image = Image.fromarray(log_image.astype('uint8'))
+    # Coerce this into a numpy array. (It may be dask.array or other array-like.)
+    arr = np.asarray(log_image.astype('uint8'))
+    auto_contrast_image = Image.fromarray(arr)
     auto_contrast_image = ImageOps.autocontrast(
                             auto_contrast_image, cutoff=0.1)
     return np.asarray(auto_contrast_image)

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -323,7 +323,7 @@ class AutoThumbnailModel(AutoPlotter):
 				# transfer function limits and scaling, rather than distorting
 				# the values in the data.
                 images = Images(
-                    field=lambda run: _log_and_auto_contrast(run[stream_name][field]),
+                    field=lambda run: _log_and_auto_contrast(run[stream_name].to_dask()[field]),
                     needs_streams=(stream_name,))
                 images.add_run(run)
                 # Make this visible to the view.

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -296,18 +296,17 @@ def _log_and_auto_contrast(data):
 
 
 class _ImageWithCustomScaling(auto_plot_builders._ShimmedImage):
-    ...
 
-    # def _transform(self, run, field):
-    #     # I am not 100% sure this is the best language feature to use for injecting
-    #     # a custom transform but otherwise reusing the rest of the logic in Images.
-    #     # That's why this method is currently private. This will either become
-    #     # public or we'll choose a different mechanism. - Dan Allan, Dec 2020
+    def _transform(self, run, field):
+        # I am not 100% sure this is the best language feature to use for injecting
+        # a custom transform but otherwise reusing the rest of the logic in Images.
+        # That's why this method is currently private. This will either become
+        # public or we'll choose a different mechanism. - Dan Allan, Dec 2020
 
-    #     # The base class gives us a 2D image by slicing the middle of any
-    #     # higher dimensions.
-    #     data = super()._transform(run, field)
-    #     return _log_and_auto_contrast(data)
+        # The base class gives us a 2D image by slicing the middle of any
+        # higher dimensions.
+        data = super()._transform(run, field)
+        return _log_and_auto_contrast(data)
 
 
 class SplashAutoImages(auto_plot_builders.AutoImages):

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -286,6 +286,11 @@ def calc_num_events(mapping_fields: List[StreamMappingField], file):
 
 
 def _log_and_auto_contrast(data):
+    # If the data is more than 2D, take the middle slice from the leading
+    # axis until there are only two axes.
+    while data.ndim > 2:
+        middle = data.shape[0] // 2
+        data = data[middle]
     log_image = data - np.min(data) + 1.001
     log_image = np.log(log_image)
     log_image = 205*log_image/(np.max(log_image))

--- a/splash_ingest/tests/test_mapping_ingestor.py
+++ b/splash_ingest/tests/test_mapping_ingestor.py
@@ -154,9 +154,9 @@ def test_hdf5_mapped_ingestor(sample_file, tmp_path):
     run = run_cache.retrieve()
     stream = run["primary"].to_dask()
     assert stream
-    dir = Path(tmp_path)
-    file = run_uid + ".png"
-    assert Path(dir / file).exists()
+    directory = Path(tmp_path, run_uid)
+    # The directory {thumbs_root}/{run_uid}/ should have at least one file in it.
+    assert os.listdir(directory)
 
 
 


### PR DESCRIPTION
This uses a yet-to-be-merged branch on bluesky-widgets: https://github.com/bluesky/bluesky-widgets/pull/80

Aside from the refactor to use bluesky-widgets, it will result in generating a directory of thumbnails per run rather than one thumbnail per run.

I think this is close, but it doesn't _quite_ work yet It seems that the thumbnail generation code is trying to operate on a `h5py.Dataset` in an `h5py.File` that has already been closed. See detail box for full traceback from pytest. This is primarily a note-to-future-self, but if anything pops out at you @dylanmcreynolds I wouldn't refuse the help. :- D

<details>

```
_________________________________________________________________________________ test_hdf5_mapped_ingestor __________________________________________________________________________________

sample_file = <HDF5 file "test.hdf5" (mode r)>, tmp_path = PosixPath('/tmp/pytest-of-dallan/pytest-30/test_hdf5_mapped_ingestor0')

    def test_hdf5_mapped_ingestor(sample_file, tmp_path):
        ingestor = MappedHD5Ingestor(Mapping(**mapping_dict), sample_file, "test_root", thumbs_root=tmp_path)
        run_cache = SingleRunCache()
        descriptors = []
        result_events = []
        result_datums = []
        start_found = False
        stop_found = False
        run_uid = ""
>       for name, doc in ingestor.generate_docstream():

splash_ingest/tests/test_mapping_ingestor.py:115: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
splash_ingest/ingestors.py:194: in generate_docstream
    self._build_thumbnail(start_doc["uid"], self._thumbs_root, bluesky_run)
splash_ingest/ingestors.py:200: in _build_thumbnail
    view = HeadlessFigures(model.figures)
../bluesky-widgets/bluesky_widgets/headless/figures.py:40: in __init__
    self._add_figure(figure_spec)
../bluesky-widgets/bluesky_widgets/headless/figures.py:55: in _add_figure
    figure = HeadlessFigure(figure_spec)
../bluesky-widgets/bluesky_widgets/headless/figures.py:125: in __init__
    self._axes[axes_spec.uuid] = MatplotlibAxes(model=axes_spec, axes=axes)
../bluesky-widgets/bluesky_widgets/_matplotlib_axes.py:60: in __init__
    self._add_image(image_spec)
../bluesky-widgets/bluesky_widgets/_matplotlib_axes.py:131: in _add_image
    array = image_spec.func(run)
../bluesky-widgets/bluesky_widgets/models/plot_builders.py:567: in _transform
    (data,) = numpy.asarray(
../../../miniconda3/envs/py38/lib/python3.8/site-packages/numpy/core/_asarray.py:83: in asarray
    return array(a, dtype, copy=False, order=order)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/xarray/core/common.py:131: in __array__
    return np.asarray(self.values, dtype=dtype)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/xarray/core/dataarray.py:569: in values
    return self.variable.values
../../../miniconda3/envs/py38/lib/python3.8/site-packages/xarray/core/variable.py:510: in values
    return _as_array_or_item(self._data)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/xarray/core/variable.py:272: in _as_array_or_item
    data = np.asarray(data)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/numpy/core/_asarray.py:83: in asarray
    return array(a, dtype, copy=False, order=order)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/array/core.py:1376: in __array__
    x = self.compute()
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/base.py:167: in compute
    (result,) = compute(self, traverse=False, **kwargs)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/base.py:452: in compute
    results = schedule(dsk, keys, **kwargs)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/threaded.py:76: in get
    results = get_async(
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/local.py:486: in get_async
    raise_exception(exc, tb)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/local.py:316: in reraise
    raise exc
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/local.py:222: in execute_task
    result = _execute_task(task, data)
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/core.py:121: in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/core.py:121: in <genexpr>
    return func(*(_execute_task(a, cache) for a in args))
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/core.py:121: in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/core.py:121: in <genexpr>
    return func(*(_execute_task(a, cache) for a in args))
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/core.py:121: in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
../../../miniconda3/envs/py38/lib/python3.8/site-packages/dask/array/core.py:100: in getter
    c = a[b]
h5py/_objects.pyx:54: in h5py._objects.with_phil.wrapper
    ???
h5py/_objects.pyx:55: in h5py._objects.with_phil.wrapper
    ???
../../../miniconda3/envs/py38/lib/python3.8/site-packages/h5py/_hl/dataset.py:489: in __getitem__
    if is_empty_dataspace(self.id):
../../../miniconda3/envs/py38/lib/python3.8/site-packages/h5py/_hl/base.py:87: in is_empty_dataspace
    if obj.get_space().get_simple_extent_type() == h5s.NULL:
h5py/_objects.pyx:54: in h5py._objects.with_phil.wrapper
    ???
h5py/_objects.pyx:55: in h5py._objects.with_phil.wrapper
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   ValueError: Not a dataset (not a dataset)

h5py/h5d.pyx:289: ValueError
```

</details>