### PR TITLE
Event config

### DIFF
--- a/splash_ingest/examples/run_ingest.py
+++ b/splash_ingest/examples/run_ingest.py
@@ -11,9 +11,11 @@ with open('/home/dylan/work/als-computing/splash-ingest/.scratch/832Mapping.json
 
 mapping = Mapping(**data)
 
-file = h5py.File("/home/dylan/data/beamlines/als832/20210128_162636_ddd.h5", "r")
+file = h5py.File("/home/dylan/data/beamlines/als832/20210129_150855_ddd.h5", "r")
 ingestor = MappedHD5Ingestor(mapping, file, "root_canal")
 for name, doc in ingestor.generate_docstream():
+    print("_________  \n")
+    print(name)
     pprint(doc)
 
 pprint(ingestor.issues)

--- a/splash_ingest/examples/run_ingest.py
+++ b/splash_ingest/examples/run_ingest.py
@@ -1,0 +1,19 @@
+import json
+from pprint import pprint
+
+import h5py
+
+from splash_ingest.ingestors import MappedHD5Ingestor
+from splash_ingest.model import Mapping
+
+with open('/home/dylan/work/als-computing/splash-ingest/.scratch/832Mapping.json', 'r') as f:
+    data = json.load(f)
+
+mapping = Mapping(**data)
+
+file = h5py.File("/home/dylan/data/beamlines/als832/20210128_162636_ddd.h5", "r")
+ingestor = MappedHD5Ingestor(mapping, file, "root_canal")
+for name, doc in ingestor.generate_docstream():
+    pprint(doc)
+
+pprint(ingestor.issues)

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -168,7 +168,11 @@ class MappedHD5Ingestor():
                     for field in mapping.mapping_fields:
                         # Go through each field in the stream. If field not marked
                         # as external, extract the value. Otherwise create a datum
-                        dataset = self._file[field.field]
+                        try:
+                            dataset = self._file[field.field]
+                        except Exception as e:
+                            self._issues.append(f"Error finding event mapping {field.field}")
+                            continue
                         if not thumbnail_created and self._thumbs_root is not None and len(dataset.shape) == 3:
                             self._build_thumbnail(start_doc['uid'], self._thumbs_root, dataset)
                             thumbnail_created = True
@@ -235,7 +239,7 @@ class MappedHD5Ingestor():
                 data_value = self._file[mapping.field]
                 metadata[encoded_key] = data_value[()].item().decode()
             except Exception as e:
-                self._issues.append(f"Error finding mapping {encoded_key} - {str(e.args)}")
+                self._issues.append(f"Error finding run_start mapping {mapping.field}")
                 continue
         return metadata
 
@@ -246,7 +250,7 @@ class MappedHD5Ingestor():
             try:
                 hdf5_dataset = self._file[mapping_field.field]
             except Exception as e:
-                self._issues.append(f"Error finding mapping {mapping_field} - {str(e.args)}")
+                self._issues.append(f"Error finding stream mapping {mapping_field}")
                 continue
             units = hdf5_dataset.attrs.get('units')
             if units is not None:
@@ -289,7 +293,7 @@ class MappedHD5Ingestor():
                 try:
                     hdf5_dataset = self._file[field.field]
                 except Exception as e:
-                    self._issues.append(f"Error finding configuraiton mapping {field.field} - {str(e.args)}")
+                    self._issues.append(f"Error finding event desc configuration mapping {field.field}")
                     continue
                 units = hdf5_dataset.attrs.get('units')
                 if units is not None:

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -270,21 +270,17 @@ class MappedHD5Ingestor():
         configuration_mapping : ConfigurationMapping
             [description]
         """
-        field_data = {}
+        field_data = {
+            "data": {},
+            "timestamps": {},
+            "data_keys": {}
+        }
         confguration = {configuration_mapping['device']: field_data}
         
         for conf_mapping in configuration_mappings:
-            mapping_fields = conf_mapping['mapping_fields']
-            data = {}
-            timestamps = {}
-            data_keys = {}
             for field in mapping_fields:
+                field_data[conf_mapping.device] = conf_mapping["field"]
                 
-            device_configuration[device_config.field].append({
-                "data": data,
-                "timespamps": sometimstamps,
-                "data_keys": somedatakeys
-            })
 
         return configuration
 

--- a/splash_ingest/ingestors.py
+++ b/splash_ingest/ingestors.py
@@ -7,7 +7,9 @@ import numpy as np
 from PIL import Image, ImageOps
 
 from .model import (
+    ConfigurationMapping,
     Mapping,
+    MappingField,
     StreamMapping,
     StreamMappingField
 )
@@ -128,6 +130,7 @@ class MappedHD5Ingestor():
                 mapping = stream_mappings[stream_name]
 
                 descriptor_keys = self._extract_stream_descriptor_keys(mapping.mapping_fields)
+                configuration = self._extract_stream_configuration(mapping.configuration)
                 stream_bundle = run_bundle.compose_descriptor(
                     data_keys=descriptor_keys,
                     name=stream_name)
@@ -257,6 +260,33 @@ class MappedHD5Ingestor():
             encoded_key = encode_key(mapping_field.field)
             descriptors[encoded_key] = descriptor
         return descriptors
+
+
+    def _extract_stream_configuration(self, configuration_mapping: ConfigurationMapping):
+        """Builds a single configuration object for the streams's event descriptor.
+
+        Parameters
+        ----------
+        configuration_mapping : ConfigurationMapping
+            [description]
+        """
+        field_data = {}
+        confguration = {configuration_mapping['device']: field_data}
+        
+        for conf_mapping in configuration_mappings:
+            mapping_fields = conf_mapping['mapping_fields']
+            data = {}
+            timestamps = {}
+            data_keys = {}
+            for field in mapping_fields:
+                
+            device_configuration[device_config.field].append({
+                "data": data,
+                "timespamps": sometimstamps,
+                "data_keys": somedatakeys
+            })
+
+        return configuration
 
 
 def encode_key(key):

--- a/splash_ingest/model.py
+++ b/splash_ingest/model.py
@@ -17,7 +17,7 @@ class StreamMappingField(MappingField):
 
 
 class StreamMapping(BaseModel):
-    mapping_fields: List[MappingField]
+    fields: List[MappingField]
     time_stamp: str = Field(title='time_stamp field', description='field to use to get time stamp values')
     conf_mappings: Optional[List[ConfigurationMapping]] = Field(title="event descriptor confguration")
 

--- a/splash_ingest/model.py
+++ b/splash_ingest/model.py
@@ -2,6 +2,8 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+SCHEMA_VERSION = 1
+
 
 class MappingField(BaseModel):
     field: str = Field(title='name of the field that is placed in the start document')
@@ -24,6 +26,7 @@ class StreamMapping(BaseModel):
 
 
 class Mapping(BaseModel):
+    schema_version: int = SCHEMA_VERSION
     name: str = Field(title='Mapping name', description='Name of this mapping')
     description: str = Field(title='Mapping description', description='Description of this mapping')
     resource_spec: str = Field(title='Resource spec', description='databroker.handler spec for the resource document' +

--- a/splash_ingest/model.py
+++ b/splash_ingest/model.py
@@ -2,20 +2,24 @@ from pydantic import BaseModel, Field
 from typing import Dict, List, Optional
 
 
-class MDMapping(BaseModel):
+class MappingField(BaseModel):
     field: str = Field(title='name of the field that is placed in the start document')
     description: Optional[str] = Field(title='description ')
 
 
-class StreamMappingField(BaseModel):
-    field: str = Field(title='name of the field')
+class ConfigurationMapping(BaseModel):
+    device: str
+    fields: List[MappingField]
+
+
+class StreamMappingField(MappingField):
     external: Optional[bool] = Field(title="Indicates whether field will be represented in the event directly or from an external file")
-    description: Optional[str] = Field(title="description of this field")
 
 
 class StreamMapping(BaseModel):
-    mapping_fields: List[StreamMappingField]
+    mapping_fields: List[MappingField]
     time_stamp: str = Field(title='time_stamp field', description='field to use to get time stamp values')
+    conf_mappings: Optional[List[ConfigurationMapping]] = Field(title="event descriptor confguration")
 
 
 class Mapping(BaseModel):
@@ -23,6 +27,6 @@ class Mapping(BaseModel):
     description: str = Field(title='Mapping description', description='Description of this mapping')
     resource_spec: str = Field(title='Resource spec', description='databroker.handler spec for the resource document' +
                                                                   'produced by the ingestor. e.g. HDF, TIFFStack, etc.')
-    md_mappings: Optional[List[MDMapping]]
+    md_mappings: Optional[List[MappingField]]
     stream_mappings: Optional[Dict[str, StreamMapping]]
     projections: Optional[List[Dict]]

--- a/splash_ingest/model.py
+++ b/splash_ingest/model.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, Field
 from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 
 class MappingField(BaseModel):
@@ -9,15 +10,15 @@ class MappingField(BaseModel):
 
 class ConfigurationMapping(BaseModel):
     device: str
-    fields: List[MappingField]
+    mapping_fields: List[MappingField]
 
 
 class StreamMappingField(MappingField):
-    external: Optional[bool] = Field(title="Indicates whether field will be represented in the event directly or from an external file")
+    external: Optional[bool] = Field(default=False, title="Indicates whether field will be represented in the event directly or from an external file")
 
 
 class StreamMapping(BaseModel):
-    fields: List[MappingField]
+    mapping_fields: List[StreamMappingField]
     time_stamp: str = Field(title='time_stamp field', description='field to use to get time stamp values')
     conf_mappings: Optional[List[ConfigurationMapping]] = Field(title="event descriptor confguration")
 

--- a/splash_ingest/tests/test_mapping_ingestor.py
+++ b/splash_ingest/tests/test_mapping_ingestor.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import h5py
 import numpy as np
 import pytest
-import pytz
 
 from databroker.core import SingleRunCache
 from splash_ingest.ingestors import (
@@ -32,9 +31,17 @@ mapping_dict = {
         ],
         "stream_mappings": {
             "primary": {
-                "thumbnail": True,
                 "time_stamp": "/process/acquisition/time_stamp",
-                "mapping_fields": [
+                "conf_mappings": [
+                        {"device": "all",
+                         "mapping_fields": [
+                            {"field": "/measurement/instrument/detector/dark_field_value"},
+                            {"field": "/measurement/instrument/attenuator/setup/filter_y"}
+                        ]
+                    }
+                ],
+                "mapping_fields":
+                [
                     {"field": "/exchange/data", "external": True},
                     {"field": "/process/acquisition/sample_position_x", "description": "tile_xmovedist"}
                 ]
@@ -66,26 +73,22 @@ def test_build_mapping():
 
 @pytest.fixture
 def sample_file(tmp_path):
-    string_dt = h5py.string_dtype(encoding='ascii')
-    local = pytz.timezone("America/Los_Angeles")
     # data = np.empty((num_frames_primary, 5, 5))
     data = np.empty((num_frames_primary, 5, 5))
     data_dark = np.empty((num_frames_darks, 5, 5))
-    primary_timestamps = np.empty((num_frames_primary), dtype=string_dt)
-    dark_timestamps = np.empty((num_frames_darks), dtype=string_dt)
+    primary_timestamps = np.empty((num_frames_primary), dtype='float64')
+    dark_timestamps = np.empty((num_frames_darks), dtype='float64')
     start_time = datetime.datetime.now()
     primary_sample_position_x = []
     for frame_num in range(0, num_frames_primary):
         data[frame_num] = np.random.random_sample((5, 5))
-        timestamp = start_time + datetime.timedelta(0, 1)  # add a second to each
-        primary_timestamps[frame_num] = (str(local.localize(timestamp, is_dst=None)))
+        primary_timestamps[frame_num] = (start_time + datetime.timedelta(0, frame_num)).timestamp()  # add a second for each frame
         primary_sample_position_x.append(float(frame_num))
     start_time = datetime.datetime.now()
     
     for dark_num in range(0, num_frames_darks):
         data_dark[dark_num, :, :] = np.random.random_sample((5, 5))
-        timestamp = start_time + datetime.timedelta(0, 1)  # add a second to each
-        dark_timestamps[dark_num] = (str(local.localize(timestamp, is_dst=None)))
+        dark_timestamps[dark_num] = (start_time + datetime.timedelta(0, num_frames_darks)).timestamp()  # add a second to each
 
     file = h5py.File(tmp_path / 'test.hdf5', 'w')
     file.create_dataset('/measurement/sample/name', data=np.array([b'my sample'], dtype='|S256'))
@@ -94,8 +97,13 @@ def sample_file(tmp_path):
     file.create_dataset('/exchange/data', data=data)
     file.create_dataset('/exchange/dark', data=data_dark)
     file.create_dataset('/process/acquisition/sample_position_x', data=primary_sample_position_x)
-    file.create_dataset('/process/acquisition/time_stamp', data=primary_timestamps, dtype=string_dt)
-    file.create_dataset('/process/acquisition/dark_time_stamp', data=dark_timestamps, dtype=string_dt)
+    file.create_dataset('/process/acquisition/time_stamp', data=primary_timestamps, dtype='float64')
+    file.create_dataset('/process/acquisition/dark_time_stamp', data=dark_timestamps, dtype='float64')
+    
+    # stream configuration fields
+    file.create_dataset('/measurement/instrument/detector/dark_field_value', data=dark_timestamps, dtype='float64')
+    file.create_dataset('/measurement/instrument/attenuator/setup/filter_y', data=dark_timestamps, dtype='float64')
+
     file.close()
     file = h5py.File(tmp_path / 'test.hdf5', 'r')
     yield file
@@ -147,6 +155,8 @@ def test_hdf5_mapped_ingestor(sample_file, tmp_path):
     assert descriptors[0]["name"] == "primary", "first descriptor is primary"
     assert descriptors[1]["name"] == "darks", "second descriptor is darks"
     assert len(descriptors[0]["data_keys"].keys()) == 2, "primary has two data_keys"
+    assert descriptors[0]['configuration'] is not None
+
 
     assert len(result_datums) == num_frames_primary + num_frames_darks
     assert len(result_events) == num_frames_primary + num_frames_darks

--- a/splash_ingest/tests/test_mapping_ingestor.py
+++ b/splash_ingest/tests/test_mapping_ingestor.py
@@ -191,7 +191,7 @@ def test_mapped_ingestor_bad_stream_field(sample_file):
     }
     ingestor = MappedHD5Ingestor(Mapping(**mapping_dict_bad_stream_field), sample_file, "test_root")
     list(ingestor.generate_docstream())
-    assert "Error finding mapping" in ingestor.issues[0]
+    assert "Error finding stream mapping" in ingestor.issues[0]
 
 
 def test_mapped_ingestor_bad_metadata_field(sample_file):
@@ -207,7 +207,7 @@ def test_mapped_ingestor_bad_metadata_field(sample_file):
     }
     ingestor = MappedHD5Ingestor(Mapping(**mapping_dict_bad_metadata_field), sample_file, "test_root")
     list(ingestor.generate_docstream())
-    assert "Error finding mapping" in ingestor.issues[0]
+    assert "Error finding run_start mapping" in ingestor.issues[0]
 
 
 def test_calc_num_events(sample_file):


### PR DESCRIPTION
Prior to this, ingestion mapping for a stream was limited to event data. This PR adds the ability to map fields from an h5 file into an event descriptor configuration field. This is good for single item state of instruments.

Also, cleans up the model for Mappings a little bit, taking advantage of some inheritance.