### PR TITLE
wait for ingestion on receive SIGTERM

### DIFF
--- a/splash_ingest/server/ingest_service.py
+++ b/splash_ingest/server/ingest_service.py
@@ -160,6 +160,7 @@ def poll_for_new_jobs(
     scicat_baseurl,
     scicat_user,
     scicat_password,
+    terminate_requested,
     thumbs_root=None
 ):
 
@@ -167,6 +168,9 @@ def poll_for_new_jobs(
     while True:
         try:
             job_list = find_unstarted_jobs()
+            if terminate_requested.state:
+                logger.info("Terminate requested, exiting")
+                return
             if len(job_list) == 0:
                 time.sleep(sleep_interval)
             else:

--- a/splash_ingest/server/poller.py
+++ b/splash_ingest/server/poller.py
@@ -60,23 +60,24 @@ class TerminateRequested():
 
 terminate_requested = TerminateRequested
 
-poll_for_new_jobs(
+
+def sigterm_handler(signum, frame):
+    logger.info(f"sig terminate received: {signum}")
+    terminate_requested.state = True
+
+
+signal.signal(signal.SIGTERM, sigterm_handler)
+signal.signal(signal.SIGINT, sigterm_handler)
+
+ingest_thread = threading.Thread(target=poll_for_new_jobs, args=(
     POLLER_SLEEP_SECONDS,
     SCICAT_BASEURL,
     SCICAT_INGEST_USER,
     SCICAT_INGEST_PASSWORD,
     terminate_requested,
     THUMBS_ROOT
-)
+))
 
-
-def sigterm_handler(signum, frame):
-    logger.info("sigterm received")
-    terminate_requested.state = True
-
-
-signal.signal(signal.SIGTERM, sigterm_handler)
-
-ingest_thread = threading.Thread(poll_for_new_jobs)
+logger.info("starting polling thread")
 ingest_thread.start()
 ingest_thread.join()

--- a/splash_ingest/server/poller.py
+++ b/splash_ingest/server/poller.py
@@ -77,4 +77,6 @@ def sigterm_handler(signum, frame):
 
 signal.signal(signal.SIGTERM, sigterm_handler)
 
-threading.Thread(poll_for_new_jobs)
+ingest_thread = threading.Thread(poll_for_new_jobs)
+ingest_thread.start()
+ingest_thread.join()


### PR DESCRIPTION
If a container shuts down (sending us SIGTERM by default) we want to complete a current ingestion. So, intercept SIGTERM and don't exit until an ingestion is complete.