### PR TITLE
change ingestor types and fix implementation

### DIFF
--- a/splash_ingest/server/ingest_service.py
+++ b/splash_ingest/server/ingest_service.py
@@ -243,7 +243,7 @@ def ingest(submitter: str, job: Job, thumbs_root=None, scicat_baseurl=None, scic
                 bluesky_context.serializer(name, document)
         logger.info(f"{job.id} databroker ingestion complete")
         issues: list[Issue] = doc_generator.issues
-        if IngestType.scicat_databroker in job.ingest_types:
+        if IngestType.scicat in job.ingest_types:
             logger.info(f"{job.id} scicat ingestion starting")
             scicat_ingestor = ScicatIngestor(
                 issues,

--- a/splash_ingest/server/model.py
+++ b/splash_ingest/server/model.py
@@ -13,7 +13,7 @@ class RevisionStamp(BaseModel):
 
 class IngestType(str, Enum):
     databroker = 'databroker'
-    scicat_databroker = 'scicat_databroker'
+    scicat = 'scicat'
 
 
 class JobStatus(str, Enum):

--- a/splash_ingest/server/tests/test_workflow.py
+++ b/splash_ingest/server/tests/test_workflow.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 import h5py
 import pytest
 from mongomock import MongoClient
@@ -101,7 +100,7 @@ def sample_file(tmp_path):
     file.close()
 
 
-def test_ingest(sample_file, init_mongomock):
+def test_ingest_databroker(sample_file, init_mongomock):
     mapping = Mapping(**mapping_dict)
     create_mapping("slartibartfast", mapping)
     mapping = find_mapping("slartibartfast", "magrathia")
@@ -117,6 +116,41 @@ def test_ingest(sample_file, init_mongomock):
     assert job.status == JobStatus.successful, f'injest completed  {job.status_history[-1]}'
     assert bluesky_context.db['run_start'].find_one({"uid": start_uid}) is not None, "job wrote start doc"
 
+    job = create_job(
+        "user1",
+        sample_file.filename,
+        "magrathia",
+        [IngestType.scicat, IngestType.databroker])
+    start_uid = ingest("slartibartfast", job)
+    job = find_job(job.id)
+    assert job is not None
+    assert job.status == JobStatus.successful, f'injest completed  {job.status_history[-1]}'
+    assert bluesky_context.db['run_start'].find_one({"uid": start_uid}) is not None, "job wrote start doc"
+
+# def test_ingest_types(sample_file, init_mongomock,  monkeypatch):
+#     from suitcase.mongo_normalized import Serializer
+    
+#     class MockSerializer(Serializer):
+#         def __call__(self, name, doc):
+#             return super().__call__(name, doc)
+
+#     def db_call(name, doc):
+#         print(name, doc)
+#     databroker_db = MongoClient().databroker_db
+    
+#     # serializer = MockSerializer(metadatastore_db=databroker_db, asset_registry_db=databroker_db)
+#     monkeypatch.setattr("suitcase.mongo_normalized", "Serializer", MockSerializer)
+#     serializer("start", {})
+#     # mapping = Mapping(**mapping_dict)
+#     # create_mapping("slartibartfast", mapping)
+#     # mapping = find_mapping("slartibartfast", "magrathia")
+#     # assert mapping.resource_spec == "MultiKeySlice", "test a field"
+#     # job = create_job(
+#     #     "user1",
+#     #     sample_file.filename,
+#     #     "magrathia",
+#     #     [IngestType.databroker])
+#     # start_uid = ingest("slartibartfast", job)
 
 
 mapping_dict = {

--- a/splash_ingest/server/tests/test_workflow.py
+++ b/splash_ingest/server/tests/test_workflow.py
@@ -116,16 +116,6 @@ def test_ingest_databroker(sample_file, init_mongomock):
     assert job.status == JobStatus.successful, f'injest completed  {job.status_history[-1]}'
     assert bluesky_context.db['run_start'].find_one({"uid": start_uid}) is not None, "job wrote start doc"
 
-    job = create_job(
-        "user1",
-        sample_file.filename,
-        "magrathia",
-        [IngestType.scicat, IngestType.databroker])
-    start_uid = ingest("slartibartfast", job)
-    job = find_job(job.id)
-    assert job is not None
-    assert job.status == JobStatus.successful, f'injest completed  {job.status_history[-1]}'
-    assert bluesky_context.db['run_start'].find_one({"uid": start_uid}) is not None, "job wrote start doc"
 
 # def test_ingest_types(sample_file, init_mongomock,  monkeypatch):
 #     from suitcase.mongo_normalized import Serializer

--- a/splash_ingest/server/tests/test_workflow_api.py
+++ b/splash_ingest/server/tests/test_workflow_api.py
@@ -26,7 +26,7 @@ def client():
 def test_create_job_api(client: TestClient):
     key = create_api_client('user1', 'sirius_cybernetics_gpp', INGEST_JOBS_API)
     request = CreateJobRequest(file_path="/foo/bar.hdf5", mapping_name="beamline_mappings",
-                               mapping_version="42", ingest_types=[IngestType.databroker, IngestType.scicat_databroker])
+                               mapping_version="42", ingest_types=[IngestType.databroker, IngestType.scicat])
     response: CreateJobResponse = client.post(url="/api/ingest/jobs", data=request.json(), headers={API_KEY_NAME: key})
     assert response.status_code == 200
     job_id = response.json()['job_id']


### PR DESCRIPTION
Fix support for different ingestor types.

While we always create a document stream, we only want to serialize to databroker if the IngestType.databroker is sent to the job