### PR TITLE
Search description

### DIFF
--- a/splash_ingest/docstream.py
+++ b/splash_ingest/docstream.py
@@ -353,6 +353,7 @@ class MappedH5Generator():
         return confguration
 
     def _get_dataset_value(self, data_set):
+        logger.debug(f"{data_set}  {data_set.dtype}")
         try:
             if "S" in data_set.dtype.str:
                 if data_set.shape == (1,):
@@ -362,7 +363,9 @@ class MappedH5Generator():
                 else:
                     return list(data_set.asstr())
             else:
+                logger.debug(f"{data_set}  {data_set[()]}")
                 return data_set[()]
+                
         except Exception as e:
             self._add_issue(f"error extracting field {data_set.name}", e)
             return None

--- a/splash_ingest/scicat.py
+++ b/splash_ingest/scicat.py
@@ -274,7 +274,7 @@ class ScicatIngestor():
             "scientificMetadata": scientific_metadata,
             "sampleId": projected_start_doc.get('sample_id'),
             "isPublished": False,
-            "searchTerms": build_search_terms(projected_start_doc)
+            "description": build_search_terms(projected_start_doc)
         }
         encoded_data = json.loads(json.dumps(data, cls=NPArrayEncoder))
 
@@ -434,7 +434,10 @@ def project_start_doc(start_doc, intent):
 def build_search_terms(projected_start):
     ''' exctract search terms from sample name to provide something pleasing to search on '''
     terms = re.split('[^a-zA-Z0-9]', projected_start.get('sample_name'))
-    return [term.lower() for term in terms if len(term) > 0]
+    description = [term.lower() for term in terms if len(term) > 0]
+    return ' '.join(description)
+
+    # return "  ".join(re.sub(r'[^A-Za-z0-9 ]+', ' ', projected_start.get('sample_name')).split());
 
 if __name__ == "__main__":
     ch = logging.StreamHandler()

--- a/splash_ingest/server/ingest_service.py
+++ b/splash_ingest/server/ingest_service.py
@@ -244,7 +244,11 @@ def ingest(submitter: str, job: Job, thumbs_root=None, scicat_baseurl=None, scic
             if name == 'descriptor':
                 descriptor_doc = document
             if IngestType.databroker in job.ingest_types:
-                bluesky_context.serializer(name, document)
+                try:
+                    bluesky_context.serializer(name, document)
+                except Exception as e:
+                    logger.error(f"Exception storing document {name}", e)
+                    raise e
         logger.info(f"{job.id} databroker ingestion complete")
         issues: list[Issue] = doc_generator.issues
         if IngestType.scicat in job.ingest_types:

--- a/splash_ingest/tests/test_scicat.py
+++ b/splash_ingest/tests/test_scicat.py
@@ -87,8 +87,7 @@ def test_scicate_ingest(sample_file):
 
 
 def test_build_search_terms():
-    terms = build_search_terms({"sample_name": "Time-is_an illusion.    Lunchtime/2x\\so."})
-    assert len(terms) == 7
+    terms = build_search_terms({"sample_name": "Time-is_an illusion. Lunchtime/2x\\so."})
     assert "time" in terms
     assert "is" in terms
     assert "an" in terms


### PR DESCRIPTION
A previous PR split the sample name into individual words and stored them in a "searchTerms" field in the Scicat Datasets collection. However, this failed on new datadasets as scicat rejected the unknown field for that collection.

So, this PR puts those terms back into a space-separated string and puts them into the "description" field, which scicat accept. This seems to behave nicely with search.