### PR TITLE
add data sample

### DIFF
--- a/splash_ingest/scicat.py
+++ b/splash_ingest/scicat.py
@@ -175,7 +175,7 @@ class ScicatIngestor():
 
 
 
-    def ingest_run(self, filepath, run_start,  descriptor_doc, thumbnails=None):
+    def ingest_run(self, filepath, run_start,  descriptor_doc, event_sample=None, thumbnails=None):
         logger.info(f"{self.job_id} Scicat ingestion started for {filepath}")
         # get token
         try:
@@ -207,7 +207,7 @@ class ScicatIngestor():
             self._add_error(f"Error creating sample for {filepath}. Continuing without sample.", e)
         
         try:
-            scientific_metadata = self._extract_scientific_metadata(descriptor_doc)
+            scientific_metadata = self._extract_scientific_metadata(descriptor_doc, event_sample)
         except Exception as e:
             self._add_error(f"Error getting scientific metadata. Continuing without.", e)
 
@@ -337,9 +337,11 @@ class ScicatIngestor():
 
 
     @staticmethod
-    def _extract_scientific_metadata(descriptor):
-        retrun_dict = {k.replace(":", "/"): v for k, v in descriptor['configuration']['all']['data'].items()}
-        return retrun_dict
+    def _extract_scientific_metadata(descriptor, event_page):
+        return_dict = {k.replace(":", "/"): v for k, v in descriptor['configuration']['all']['data'].items()}
+        if event_page:
+            return_dict['data_sample'] = event_page
+        return return_dict
 
     @staticmethod
     def _get_file_mod_time(pathobj):

--- a/splash_ingest/server/ingest_service.py
+++ b/splash_ingest/server/ingest_service.py
@@ -293,6 +293,7 @@ def ingest(submitter: str, job: Job, thumbs_root=None, scicat_baseurl=None, scic
 
 def sample_event_page(event_page, sample_size=10):
     df = pd.DataFrame(data=event_page['data'])
+    df = df.rename(columns=lambda s: s.replace(":", "/"))
     if len(df) == 0:
         return {}
     step = len(df) // sample_size


### PR DESCRIPTION
This PR implements a data sampling mechanism for ingesting into scicat.

Takes advantage of the databroker event_page mechanism, using Pandas to sample event_page and produce a dictionary that slices through producing 10 samples spread evenly across the set of events of each field.

Closes #20 