### PR TITLE
Scicat fields

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/mappings/832Mapping.json
+++ b/mappings/832Mapping.json
@@ -37,6 +37,10 @@
                 "description": null
             },
             {
+                "field": "/measurement/sample/experimenter/email",
+                "description": null
+            }
+            {
                 "field": "/measurement/sample/experiment/pi",
                 "description": null
             },
@@ -177,6 +181,11 @@
             "experimenter_name": {
                 "type": "configuration",
                 "field": ":measurement:sample:experimenter:name",
+                "location": "start"
+            },
+            "experimenter_email": {
+                "type": "configuration",
+                "field": ":measurement:sample:experimenter:email",
                 "location": "start"
             },
             "pi_name": {

--- a/mappings/832Mapping.json
+++ b/mappings/832Mapping.json
@@ -39,7 +39,7 @@
             {
                 "field": "/measurement/sample/experimenter/email",
                 "description": null
-            }
+            },
             {
                 "field": "/measurement/sample/experiment/pi",
                 "description": null
@@ -49,7 +49,8 @@
                 "description": null
             },
             {
-                "field": "/process/acquisition/start_date"
+                "field": "/process/acquisition/start_date",
+                "description": null
             }
 
         ],

--- a/splash_ingest/docstream.py
+++ b/splash_ingest/docstream.py
@@ -9,13 +9,13 @@ import event_model
 import numpy as np
 from PIL import Image, ImageOps
 
-
-
+from .util import IssueCollectorMixin
 from .model import (
     ConfigurationMapping,
     Issue,
     Mapping,
     MappingField,
+    Severity,
     StreamMapping,
     StreamMappingField,
     ThumbnailInfo
@@ -25,6 +25,7 @@ logger = logging.getLogger("splash_ingest.docstream")
 
 can_info = logger.isEnabledFor(logging.INFO)
 can_debug = logger.isEnabledFor(logging.DEBUG)
+
 class MappingNotFoundError(Exception):
     def __init__(self, location, missing_field):
         self.missing_field = missing_field
@@ -49,7 +50,7 @@ class ThumnailDimensionError(Exception):
     ''' specified thumnail has unsupported dimensions '''
     pass
 
-class MappedH5Generator():
+class MappedH5Generator(IssueCollectorMixin):
     """Provides an ingestor (make of event_model docstreams) based on a single hdf5 file
     and mapping document.
 
@@ -59,9 +60,8 @@ class MappedH5Generator():
 
 
     """
-    def __init__(self, mapping: Mapping, file, reference_root_name, pack_pages=True, data_groups=[], thumbs_root=None):
+    def __init__(self, issues: List[Issue], mapping: Mapping, file, reference_root_name, pack_pages=True, data_groups=[], thumbs_root=None):
         """
-
         Parameters
         ----------
         mapping : Mapping
@@ -76,13 +76,15 @@ class MappedH5Generator():
             projection to insert into the run_start document, by default None
         """
         super().__init__()
+        self.stage = "databroker"
+        self._issues = issues
         self._mapping = mapping
         self._file = file
         self._reference_root_name = reference_root_name
         self._data_groups = data_groups
         self._thumbs_root = thumbs_root
-        self._thumbnails: [Path] = []
-        self._issues: list[Issue] = []
+        self._thumbnails: list[Path] = []
+  
         self._run_bundle = None
         self._pack_pages = pack_pages
         if self._pack_pages:
@@ -93,9 +95,6 @@ class MappedH5Generator():
     def thumbnails(self):
         return self._thumbnails
 
-    @property
-    def issues(self):
-        return self._issues
 
     def generate_docstream(self):
         """Generates docstream documents
@@ -160,8 +159,8 @@ class MappedH5Generator():
             self._data_groups.append(self._get_dataset_value(self._file['/measurement/sample/experiment/proposal']))
         return self._data_groups
 
-    def _add_issue(self, message, exception=None):
-        self._issues.append(Issue(stage="gen_docsteram", msg=message, exception=exception))
+
+
 
 
     def _process_stream(self, stream_name, resource_doc):
@@ -184,13 +183,13 @@ class MappedH5Generator():
         try:
             num_events = calc_num_events(stream_mapping.mapping_fields, self._file)
         except FieldNotInResourceError as e:
-            self._add_issue("Error finding stream mapping", e)
+            self.add_warning("Error finding stream mapping", e)
 
         logger.info(f"expecting {str(num_events)} events")
         try:
             time_stamp_dataset = self._file[stream_timestamp_field][()]
         except Exception as e:
-            self._add_issue(f"Error fetching timestamp for {stream_name}", e)
+            self.add_warning(f"Error fetching timestamp for {stream_name}", e)
             return
 
         if (stream_mapping.thumbnail_info and stream_mapping.thumbnail_info.number > 0
@@ -203,14 +202,14 @@ class MappedH5Generator():
                 logger.info(f"created thumbnail {file}")
                 self._thumbnails.append(file)
             except Exception as e:
-                self._add_issue("Error producing  thumbnail", e)
+                self.add_warning("Error producing  thumbnail", e)
 
         # produce documents for each event (event and datum)
         for event_num in range(0, num_events):
             try:
                 time_stamp = time_stamp_dataset[event_num]
             except Exception:
-                self._add_issue(f"Missing timestamp for"
+                self.add_warning(f"Missing timestamp for"
                                 f"{stream_name} slice: {str(event_num)}")
                 continue
 
@@ -277,7 +276,7 @@ class MappedH5Generator():
             try:
                 metadata[encoded_key] = self._get_dataset_value(self._file[mapping.field])
             except Exception as e:
-                self._add_issue(f"Error finding run_start mapping {mapping.field}", e)
+                self.add_warning(f"Error finding run_start mapping {mapping.field}", e)
                 continue
         logger.debug("leaving  _extract_metadata")
         return metadata
@@ -290,7 +289,7 @@ class MappedH5Generator():
             try:
                 hdf5_dataset = self._file[mapping_field.field]
             except Exception as e:
-                self._add_issue(f"Error finding stream mapping {mapping_field}", e)
+                self.add_warning(f"Error finding stream mapping {mapping_field}", e)
                 continue
             units = hdf5_dataset.attrs.get('units')
             if units is not None:
@@ -334,7 +333,7 @@ class MappedH5Generator():
                 try:
                     hdf5_dataset = self._file[field.field]
                 except Exception as e:
-                    self._add_issue(f"Error finding event desc configuration mapping {field.field}", e)
+                    self.add_warning(f"Error finding event desc configuration mapping {field.field}", e)
                     continue
                 units = hdf5_dataset.attrs.get('units')
                 if units is not None:
@@ -367,7 +366,7 @@ class MappedH5Generator():
                 return data_set[()]
                 
         except Exception as e:
-            self._add_issue(f"error extracting field {data_set.name}", e)
+            self.add_warning(f"error extracting field {data_set.name}", e)
             return None
 
 
@@ -395,7 +394,7 @@ def create_event(file, stream_name, timestamp, stream_mapping, resource_doc, str
         try:
             dataset = file[field.field]
         except Exception as e:
-            # self._add_issue(f"Error finding event mapping {field.field}", e)
+            # self._add_warning(f"Error finding event mapping {field.field}", e)
             return
 
         encoded_key = encode_key(field.field)

--- a/splash_ingest/docstream.py
+++ b/splash_ingest/docstream.py
@@ -83,7 +83,7 @@ class MappedH5Generator(IssueCollectorMixin):
         self._reference_root_name = reference_root_name
         self._data_groups = data_groups
         self._thumbs_root = thumbs_root
-        self._thumbnails: list[Path] = []
+        self._thumbnails: List[Path] = []
   
         self._run_bundle = None
         self._pack_pages = pack_pages

--- a/splash_ingest/model.py
+++ b/splash_ingest/model.py
@@ -1,4 +1,5 @@
 import enum
+
 from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
@@ -51,7 +52,7 @@ class Issue(BaseModel):
     severity: Severity
     stage: str
     msg: str
-    exception: Union[Exception, None]
+    exception: Union[str, None]
 
     class Config:
         arbitrary_types_allowed = True

--- a/splash_ingest/model.py
+++ b/splash_ingest/model.py
@@ -1,3 +1,4 @@
+import enum
 from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
@@ -41,8 +42,13 @@ class Mapping(BaseModel):
     stream_mappings: Optional[Dict[str, StreamMapping]]
     projections: Optional[List[Dict]]
 
+class Severity(enum.Enum):
+    warning = "warning"
+    error = "error"
+
 
 class Issue(BaseModel):
+    severity: Severity
     stage: str
     msg: str
     exception: Union[Exception, None]

--- a/splash_ingest/model.py
+++ b/splash_ingest/model.py
@@ -43,7 +43,7 @@ class Mapping(BaseModel):
     stream_mappings: Optional[Dict[str, StreamMapping]]
     projections: Optional[List[Dict]]
 
-class Severity(enum.Enum):
+class Severity(str, enum.Enum):
     warning = "warning"
     error = "error"
 

--- a/splash_ingest/scicat.py
+++ b/splash_ingest/scicat.py
@@ -15,8 +15,9 @@ from typing import List
 import numpy as np
 import requests  # for HTTP requests
 
-from splash_ingest.docstream import MappedH5Generator
-from splash_ingest.model import Mapping, Issue
+from .docstream import MappedH5Generator
+from .model import Mapping, Issue
+from .util import IssueCollectorMixin
 
 logger = logging.getLogger("splash_ingest.scicat")
 can_debug = logger.isEnabledFor(logging.DEBUG)
@@ -27,7 +28,7 @@ class ScicatCommError(Exception):
         self.message = message
 
 
-class ScicatIngestor():
+class ScicatIngestor(IssueCollectorMixin):
     # settables
     host = "localhost:3000"
     baseurl = "http://" + host + "/api/v3/"
@@ -47,8 +48,9 @@ class ScicatIngestor():
     job_id = "0"
     test = False
 
-    def __init__(self, issues: List[Issue], **kwargs):
-        self.issues = issues
+    def __init__(self, issues: list[Issue], **kwargs):
+        self.stage = "scicat"
+        self._issues = issues
         # nothing to do
         for key, value in kwargs.items():
             assert key in self.settables, f"key {key} is not a valid input argument"
@@ -57,14 +59,6 @@ class ScicatIngestor():
         if self.baseurl[-1] != "/":
             self.baseurl = self.baseurl + "/"
             logger.info(f"Baseurl corrected to: {self.baseurl}")
-
-    def _add_error(self, msg: str, exc: Exception):
-        logger.error(f"{self.job_id} {msg} encountered exception: {exc}")
-        self.issues.append(Issue(stage="scicat", msg=msg, exception=exc))
-
-    def _add_issue(self, msg):
-        logger.info(f"{self.job_id} {msg}")
-        self.issues.append(Issue(stage="scicat", msg=msg))
 
     def _get_token(self, username=None, password=None):
         if username is None:
@@ -86,7 +80,7 @@ class ScicatIngestor():
             logger.error(f'{self.job_id} ** Error received: {response}')
             err = response.json()["error"]
             logger.error(f'{self.job_id} {err["name"]}, {err["statusCode"]}: {err["message"]}')
-            self._add_issue(f'error getting token {err["name"]}, {err["statusCode"]}: {err["message"]}')
+            self.add_issue(f'error getting token {err["name"]}, {err["statusCode"]}: {err["message"]}')
             return None
 
         data = response.json()
@@ -144,24 +138,23 @@ class ScicatIngestor():
             # pipe contents of the file through
             return hashlib.md5(file_to_check.read()).hexdigest()
 
-
     def ingest_run(self, filepath, run_start,  descriptor_doc, event_sample=None, thumbnails=None):
         logger.info(f"{self.job_id} Scicat ingestion started for {filepath}")
         # get token
         try:
             self.token = self._get_token(username=self.username, password=self.password)
         except Exception as e:
-            self._add_error("Could not generate token. Exiting.", e)
+            self.add_error("Could not generate token. Exiting.", e)
             return
         if not self.token:
-            self._add_issue("could not create token, exiting")
+            self.add_error("could not create token, exiting")
             return
 
         logger.info(f"{self.job_id} Ingesting file {filepath}")
         try:
             projected_start_doc = project_start_doc(run_start, "app")
         except Exception as e:
-            self._add_error("error projecting start document. Exiting.", e)
+            self.add_error("error projecting start document. Exiting.", e)
             return
         
         if can_debug:
@@ -174,12 +167,12 @@ class ScicatIngestor():
         try:
             self._create_sample(projected_start_doc, access_groups, owner_group)
         except Exception as e:
-            self._add_error(f"Error creating sample for {filepath}. Continuing without sample.", e)
+            self.add_error(f"Error creating sample for {filepath}. Continuing without sample.", e)
         
         try:
-            scientific_metadata = self.extract_scientific_metadata(descriptor_doc, event_sample)
+            scientific_metadata = self._extract_scientific_metadata(descriptor_doc, event_sample)
         except Exception as e:
-            self._add_error(f"Error getting scientific metadata. Continuing without.", e)
+            self.add_error(f"Error getting scientific metadata. Continuing without.", e)
 
         try:
             self._create_raw_dataset(
@@ -189,7 +182,7 @@ class ScicatIngestor():
                 filepath,
                 thumbnails)
         except Exception as e:
-            self._add_error("Error creating raw data set.", e)
+            self.add_error("Error creating raw data set.", e)
 
     def _create_sample(self, projected_start_doc, access_groups, owner_group):
         sample = {
@@ -212,25 +205,34 @@ class ScicatIngestor():
             err = resp.json()["error"]
             raise ScicatCommError(f"Error creating Sample {err}")
 
+    def _get_field(self, field_name: str, projected_dict: dict, default_val):
+        "some fields are required by scicat but we don't want to blow up, rather provide a default value"
+        if projected_dict.get(field_name):
+            return projected_dict.get(field_name)
+        else:
+            self.add_warning(f"missing field {field_name} defaulting to {str(default_val)}")
+            return default_val
 
     def _create_raw_dataset(self, projected_start_doc, scientific_metadata, access_groups, owner_group, filepath, thumbnails):
-        principalInvestigator = projected_start_doc.get('pi_name')
-        if not principalInvestigator:
-            principalInvestigator = "uknonwn"
-        creationLocation = projected_start_doc.get('beamline')
-        if not creationLocation:
-            creationLocation = "unknown"
-        # model for the raw datasets as defined in the RawDatasets
+        # model for the raw datasets as defined in the RawDatasets, required fields:
+        # pid
+        # owner
+        # contactEmail
+        # sourceFolder
+        # creationTime
+        # type
+
+        creation_time_raw = self._get_field('collection_date', projected_start_doc, [datetime.now()])
+        creation_time = (datetime.isoformat(datetime.fromtimestamp(creation_time_raw[0])) + "Z")
         data = { 
-            "owner": projected_start_doc.get('pi_name'),
-            "contactEmail": "dmcreynolds@lbl.gov",
+            "owner": self._get_field('pi_name', projected_start_doc, "unavailable"),
+            "contactEmail": self._get_field('experimenter_email', projected_start_doc, "unavailable"),
             "createdBy": self.username,
             "updatedBy": self.username,
-            "creationLocation": creationLocation,
+            "creationLocation": self._get_field('beamline', projected_start_doc, 'unkown'),
             "updatedAt": datetime.isoformat(datetime.utcnow()) + "Z",
             "createdAt": datetime.isoformat(datetime.utcnow()) + "Z",
-            "creationTime": (datetime.isoformat(datetime.fromtimestamp(
-                projected_start_doc.get('collection_date')[0])) + "Z"),
+            "creationTime": creation_time,
             "datasetName": filepath.stem,
             "type": "raw",
             "instrumentId": projected_start_doc.get('instrument_name'),
@@ -238,7 +240,7 @@ class ScicatIngestor():
             "accessGroups": access_groups,
             "proposalId": projected_start_doc.get('proposal'),
             "dataFormat": "DX",
-            "principalInvestigator": principalInvestigator,
+            "principalInvestigator": self._get_field('pi_name', projected_start_doc, "unknown"),
             "sourceFolder": filepath.parent.as_posix(),
             "size": self._get_file_size(filepath),
             "scientificMetadata": scientific_metadata,
@@ -307,14 +309,10 @@ class ScicatIngestor():
 
 
     @staticmethod
-    def extract_scientific_metadata(descriptor, event_sample):
-        return_dict = {}
-        if descriptor:
-            return_dict = {k.replace(":", "/"): v for k, v in descriptor['configuration']['all']['data'].items()}
-        if event_sample:
-            return_dict.update(event_sample)
-        if len(return_dict) > 0:
-            return_dict = dict(sorted(return_dict.items(), key=lambda item: item[0]))
+    def _extract_scientific_metadata(descriptor, event_page):
+        return_dict = {k.replace(":", "/"): v for k, v in descriptor['configuration']['all']['data'].items()}
+        if event_page:
+            return_dict['data_sample'] = event_page
         return return_dict
 
     @staticmethod
@@ -367,6 +365,7 @@ def gen_ev_docs(scm: ScicatIngestor, filename: str, mapping_file: str):
     map = Mapping(**data)
     with h5py.File(filename, 'r') as h5_file:
         ingestor = MappedH5Generator(
+            [],
             map,
             h5_file,
             'root',

--- a/splash_ingest/scicat.py
+++ b/splash_ingest/scicat.py
@@ -48,7 +48,8 @@ class ScicatIngestor(IssueCollectorMixin):
     job_id = "0"
     test = False
 
-    def __init__(self, issues: list[Issue], **kwargs):
+    def __init__(self, dataset_id, issues: List[Issue], **kwargs):
+        self.dataset_id = dataset_id
         self.stage = "scicat"
         self._issues = issues
         # nothing to do
@@ -139,7 +140,7 @@ class ScicatIngestor(IssueCollectorMixin):
             return hashlib.md5(file_to_check.read()).hexdigest()
 
     def ingest_run(self, filepath, run_start,  descriptor_doc, event_sample=None, thumbnails=None):
-        logger.info(f"{self.job_id} Scicat ingestion started for {filepath}")
+        logger.info(f"{self.job_id} Scicat ingestion started for {filepath} and uid {self.dataset_id}")
         # get token
         try:
             self.token = self._get_token(username=self.username, password=self.password)
@@ -224,7 +225,8 @@ class ScicatIngestor(IssueCollectorMixin):
 
         creation_time_raw = self._get_field('collection_date', projected_start_doc, [datetime.now()])
         creation_time = (datetime.isoformat(datetime.fromtimestamp(creation_time_raw[0])) + "Z")
-        data = { 
+        data = {
+            "pid": self.dataset_id,
             "owner": self._get_field('pi_name', projected_start_doc, "unavailable"),
             "contactEmail": self._get_field('experimenter_email', projected_start_doc, "unavailable"),
             "createdBy": self.username,

--- a/splash_ingest/server/ingest_service.py
+++ b/splash_ingest/server/ingest_service.py
@@ -255,10 +255,11 @@ def ingest(submitter: str, job: Job, thumbs_root=None, scicat_baseurl=None, scic
                     logger.error(f"Exception storing document {name}", e)
                     raise e
         logger.info(f"{job.id} databroker ingestion complete")
-        issues: list[Issue] = doc_generator.issues
+        issues: List[Issue] = doc_generator.issues
         if IngestType.scicat in job.ingest_types:
             logger.info(f"{job.id} scicat ingestion starting")
             scicat_ingestor = ScicatIngestor(
+                start_uid,
                 issues,
                 baseurl=scicat_baseurl,
                 username=scicat_user,

--- a/splash_ingest/server/ingest_service.py
+++ b/splash_ingest/server/ingest_service.py
@@ -232,7 +232,7 @@ def ingest(submitter: str, job: Job, thumbs_root=None, scicat_baseurl=None, scic
         logger.info(f"mapping found for {job.id} for file {job.document_path}") 
         mapping = mapping_with_revision
         file = h5py.File(job.document_path, "r")
-        doc_generator = MappedH5Generator(mapping, file, 'mapping_ingestor', thumbs_root=thumbs_root, pack_pages=True)
+        doc_generator = MappedH5Generator( [], mapping, file, 'mapping_ingestor', thumbs_root=thumbs_root, pack_pages=True)
         # we always generate a docstream, but depending on the ingestors listed in the job we may do different things
         # with the docstream
 

--- a/splash_ingest/server/model.py
+++ b/splash_ingest/server/model.py
@@ -4,6 +4,7 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from ..model import Issue
 
 class RevisionStamp(BaseModel):
     user: str
@@ -29,6 +30,7 @@ class StatusItem(BaseModel):
     status: JobStatus
     log: Optional[str]
     submitter: str
+    issues: Optional[list[Issue]]
 
 
 class Job(BaseModel):

--- a/splash_ingest/server/model.py
+++ b/splash_ingest/server/model.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from enum import Enum
+
 from typing import Optional, List
 
 from pydantic import BaseModel
@@ -30,7 +31,7 @@ class StatusItem(BaseModel):
     status: JobStatus
     log: Optional[str]
     submitter: str
-    issues: Optional[list[Issue]]
+    issues: Optional[List[Issue]]
 
 
 class Job(BaseModel):

--- a/splash_ingest/server/tests/test_workflow_api.py
+++ b/splash_ingest/server/tests/test_workflow_api.py
@@ -27,7 +27,7 @@ def test_create_job_api(client: TestClient):
     key = create_api_client('user1', 'sirius_cybernetics_gpp', INGEST_JOBS_API)
     request = CreateJobRequest(file_path="/foo/bar.hdf5", mapping_name="beamline_mappings",
                                mapping_version="42", ingest_types=[IngestType.databroker, IngestType.scicat])
-    response: CreateJobResponse = client.post(url="/api/ingest/jobs", data=request.json(), headers={API_KEY_NAME: key})
+    response: CreateJobResponse = client.post(url="/api/ingest/jobs", json=request.dict(), headers={API_KEY_NAME: key})
     assert response.status_code == 200, f"failed with message {response.content}"
     job_id = response.json()['job_id']
 
@@ -43,7 +43,7 @@ def test_mapping_api(client: TestClient):
     key = create_api_client('user1', 'sirius_cybernetics_gpp', INGEST_JOBS_API)
     request = Mapping(name="foo", description="bar", resource_spec="blah")
     response: CreateMappingResponse = client.post(url="/api/ingest/mappings",
-                                                  data=request.json(),
+                                                  json=request.dict(),
                                                   headers={API_KEY_NAME: key})
     assert response.status_code == 200, f"failed with message {response.content}"
     response = client.get(url="/api/ingest/mappings/" + "foo",

--- a/splash_ingest/server/tests/test_workflow_api.py
+++ b/splash_ingest/server/tests/test_workflow_api.py
@@ -28,7 +28,7 @@ def test_create_job_api(client: TestClient):
     request = CreateJobRequest(file_path="/foo/bar.hdf5", mapping_name="beamline_mappings",
                                mapping_version="42", ingest_types=[IngestType.databroker, IngestType.scicat])
     response: CreateJobResponse = client.post(url="/api/ingest/jobs", data=request.json(), headers={API_KEY_NAME: key})
-    assert response.status_code == 200
+    assert response.status_code == 200, f"failed with message {response.content}"
     job_id = response.json()['job_id']
 
     response = client.get(url="/api/ingest/jobs/" + job_id)
@@ -45,7 +45,7 @@ def test_mapping_api(client: TestClient):
     response: CreateMappingResponse = client.post(url="/api/ingest/mappings",
                                                   data=request.json(),
                                                   headers={API_KEY_NAME: key})
-    assert response.status_code == 200
+    assert response.status_code == 200, f"failed with message {response.content}"
     response = client.get(url="/api/ingest/mappings/" + "foo",
                           headers={API_KEY_NAME: key})
     mapping = Mapping(**response.json())   # first item because we have a version tag in there

--- a/splash_ingest/tests/test_ingestors.py
+++ b/splash_ingest/tests/test_ingestors.py
@@ -130,7 +130,7 @@ def sample_file_no_timestamp(tmp_path):
 
 def test_hdf5_mapped_ingestor(sample_file, tmp_path):
     ingestor = MappedH5Generator(
-        Mapping(**mapping_dict), sample_file, "test_root", pack_pages=False, thumbs_root=tmp_path)
+        [], Mapping(**mapping_dict), sample_file, "test_root", pack_pages=False, thumbs_root=tmp_path)
     run_cache = SingleRunCache()
     descriptors = []
     result_events = []
@@ -188,7 +188,7 @@ def test_hdf5_mapped_ingestor(sample_file, tmp_path):
 
 def test_hdf5_mapped_ingestor_packed(sample_file, tmp_path):
     ingestor = MappedH5Generator(
-        Mapping(**mapping_dict), sample_file, "test_root", pack_pages=True, thumbs_root=tmp_path)
+        [], Mapping(**mapping_dict), sample_file, "test_root", pack_pages=True, thumbs_root=tmp_path)
     run_cache = SingleRunCache()
 
     # expect one set of pages each of 2 streams
@@ -228,7 +228,7 @@ def test_mapped_ingestor_bad_stream_field(sample_file):
             },
         }
     }
-    ingestor = MappedH5Generator(Mapping(**mapping_dict_bad_stream_field), sample_file, "test_root")
+    ingestor = MappedH5Generator([], Mapping(**mapping_dict_bad_stream_field), sample_file, "test_root")
     list(ingestor.generate_docstream())
     issue = ingestor.issues[0]
     assert "Error finding stream mapping" in issue.msg
@@ -245,7 +245,7 @@ def test_mapped_ingestor_bad_metadata_field(sample_file):
         ],
         "stream_mappings": {}
     }
-    ingestor = MappedH5Generator(Mapping(**mapping_dict_bad_metadata_field), sample_file, "test_root")
+    ingestor = MappedH5Generator([], Mapping(**mapping_dict_bad_metadata_field), sample_file, "test_root")
     list(ingestor.generate_docstream())
     issue = ingestor.issues[0]
     assert "Error finding run_start mapping" in issue.msg
@@ -275,7 +275,7 @@ def test_timestamp_error(sample_file):
             }
         }
     }
-    ingestor = MappedH5Generator(Mapping(**mapping), sample_file, "test_root")
+    ingestor = MappedH5Generator([], Mapping(**mapping), sample_file, "test_root")
 
     list(ingestor.generate_docstream())
     issue = ingestor.issues[0]
@@ -287,13 +287,13 @@ def test_key_transformation():
 
 
 def test_data_groups(sample_file):
-    ingestor = MappedH5Generator(Mapping(**mapping_dict), sample_file, "test_root")
+    ingestor = MappedH5Generator([], Mapping(**mapping_dict), sample_file, "test_root")
     for name, doc in ingestor.generate_docstream():
         if name == 'start':
             assert doc['data_groups'] == []
             continue
 
-    ingestor = MappedH5Generator(Mapping(**mapping_dict), sample_file, "test_root", data_groups=['bealine1', 'users1'])
+    ingestor = MappedH5Generator([], Mapping(**mapping_dict), sample_file, "test_root", data_groups=['bealine1', 'users1'])
     for name, doc in ingestor.generate_docstream():
         if name == 'start':
             assert doc['data_groups'] == ['bealine1', 'users1']

--- a/splash_ingest/tests/test_scicat.py
+++ b/splash_ingest/tests/test_scicat.py
@@ -1,7 +1,9 @@
-import h5py
+
 from pathlib import Path
+from typing import List
+
+import h5py
 import pytest
-# import requests
 import requests_mock
 
 from ..scicat import project_start_doc, ScicatIngestor, build_search_terms
@@ -77,15 +79,15 @@ def test_projected_start():
 
 def add_mock_requests(mock_request):
     mock_request.post("http://localhost:3000/api/v3/Users/login", json={"id": "foobar"})
-    mock_request.post("http://localhost:3000/api/v3/Samples", json={"sampleId": "sample_id"})
+    mock_request.post("http://localhost:3000/api/v3/Samples", json={"sampleId": "dataset_id"})
     mock_request.post("http://localhost:3000/api/v3/RawDatasets/replaceOrCreate", json={"pid": "42"})
     mock_request.post("http://localhost:3000/api/v3/RawDatasets/42/origdatablocks", json={"response": "random"})
 
 def test_scicate_ingest(sample_file):
     with requests_mock.Mocker() as mock_request:
         add_mock_requests(mock_request)
-        issues: list[Issue] = []
-        scicat = ScicatIngestor(issues, host="localhost:3000")
+        issues: List[Issue] = []
+        scicat = ScicatIngestor("dataset_id", issues, host="localhost:3000")
         scicat.ingest_run(Path(sample_file.filename), start_doc, descriptor_doc)
         assert len(issues) == 0
 
@@ -106,8 +108,8 @@ def test_build_search_terms():
 def test_get_field():
     with requests_mock.Mocker() as mock_request:
         add_mock_requests(mock_request)
-        issues: list[Issue] = []
-        scicat = ScicatIngestor(issues, host="localhost:3000")
+        issues: List[Issue] = []
+        scicat = ScicatIngestor("dataset_id", issues, host="localhost:3000")
         projected_doc = {
             "foo": "bar"
         }
@@ -141,6 +143,7 @@ def test_extract_scientific_metadata():
 
 
 start_doc = {
+    "uid": "dataset_id",
     "image_data": [1],
     "sample_name": "sample_name",
     "sample_id": "sample_id",

--- a/splash_ingest/tests/test_scicat.py
+++ b/splash_ingest/tests/test_scicat.py
@@ -74,17 +74,23 @@ def test_projected_start():
     assert projected['collection_date'] == [1619564232.0]
 
 
+
+def add_mock_requests(mock_request):
+    mock_request.post("http://localhost:3000/api/v3/Users/login", json={"id": "foobar"})
+    mock_request.post("http://localhost:3000/api/v3/Samples", json={"sampleId": "sample_id"})
+    mock_request.post("http://localhost:3000/api/v3/RawDatasets/replaceOrCreate", json={"pid": "42"})
+    mock_request.post("http://localhost:3000/api/v3/RawDatasets/42/origdatablocks", json={"response": "random"})
+
 def test_scicate_ingest(sample_file):
     with requests_mock.Mocker() as mock_request:
-        mock_request.post("http://localhost:3000/api/v3/Users/login", json={"id": "foobar"})
-        mock_request.post("http://localhost:3000/api/v3/Samples", json={"sampleId": "sample_id"})
-        mock_request.post("http://localhost:3000/api/v3/RawDatasets/replaceOrCreate", json={"pid": "42"})
-        mock_request.post("http://localhost:3000/api/v3/RawDatasets/42/origdatablocks", json={"response": "random"})
+        add_mock_requests(mock_request)
         issues: list[Issue] = []
         scicat = ScicatIngestor(issues, host="localhost:3000")
         scicat.ingest_run(Path(sample_file.filename), start_doc, descriptor_doc)
         assert len(issues) == 0
 
+
+    
 
 def test_build_search_terms():
     terms = build_search_terms({"sample_name": "Time-is_an illusion. Lunchtime/2x\\so."})
@@ -95,6 +101,20 @@ def test_build_search_terms():
     assert "lunchtime" in terms
     assert "2x" in terms
     assert "so" in terms
+
+
+def test_get_field():
+    with requests_mock.Mocker() as mock_request:
+        add_mock_requests(mock_request)
+        issues: list[Issue] = []
+        scicat = ScicatIngestor(issues, host="localhost:3000")
+        projected_doc = {
+            "foo": "bar"
+        }
+        assert scicat._get_field("foo", projected_doc, "nothing") == "bar"
+        assert scicat._get_field("foo2", projected_doc, "nothing") == "nothing"
+        assert len(scicat.issues) == 1
+        assert "missing field" in scicat.issues[0].msg
 
 
 def test_extract_scientific_metadata():
@@ -112,7 +132,7 @@ def test_extract_scientific_metadata():
     event_sample ={
         "/a/c/1": [2]
     }
-    sci_meta = ScicatIngestor.extract_scientific_metadata(descriptor, event_sample)
+    sci_meta = ScicatIngestor._extract_scientific_metadata(descriptor, event_sample)
     keys = sci_meta.keys()
     assert list(keys) == sorted(keys)
 
@@ -130,6 +150,7 @@ start_doc = {
     "proposal": "proposal",
     "experiment_title": "experiment_title",
     "experimenter_name": "experimenter_name",
+    "experimenter_email": "experimenter_email",
     "pi_name": "pi_name",
     "projections": [
     {
@@ -182,6 +203,11 @@ start_doc = {
             "experimenter_name": {
                 "type": "configuration",
                 "field": "experimenter_name",
+                "location": "start"
+            },
+             "experimenter_email": {
+                "type": "configuration",
+                "field": "experimenter_email",
                 "location": "start"
             },
             "pi_name": {

--- a/splash_ingest/util.py
+++ b/splash_ingest/util.py
@@ -1,0 +1,17 @@
+from .model import Issue, Severity
+
+
+class IssueCollectorMixin():
+    _issues:list[Issue] = []
+    def __init__(self, **kwargs) -> None:
+        self.stage = kwargs.get('stage') if kwargs.get('stage') else 'unknown'
+
+    @property
+    def issues(self):
+        return self._issues
+
+    def add_warning(self, message, exception=None):
+        self._issues.append(Issue(stage=self.stage, severity=Severity.warning, msg=message, exception=exception))
+
+    def add_error(self, message, exception=None):
+        self._issues.append(Issue(stage=self.stage, severity=Severity.error, msg=message, exception=exception))

--- a/splash_ingest/util.py
+++ b/splash_ingest/util.py
@@ -11,7 +11,19 @@ class IssueCollectorMixin():
         return self._issues
 
     def add_warning(self, message, exception=None):
-        self._issues.append(Issue(stage=self.stage, severity=Severity.warning, msg=message, exception=exception))
+        self._issues.append(Issue(
+            stage=self.stage, 
+            severity=Severity.warning,
+            msg=message, 
+            exception=IssueCollectorMixin.serialize_execption(exception)))
 
     def add_error(self, message, exception=None):
-        self._issues.append(Issue(stage=self.stage, severity=Severity.error, msg=message, exception=exception))
+        self._issues.append(Issue(
+            stage=self.stage, 
+            severity=Severity.error, 
+            msg=message, 
+            exception=IssueCollectorMixin.serialize_execption(exception)))
+
+    @staticmethod
+    def serialize_execption(exception: Exception) -> str:
+        return repr(exception)

--- a/splash_ingest/util.py
+++ b/splash_ingest/util.py
@@ -1,8 +1,10 @@
+from typing import List
+
 from .model import Issue, Severity
 
 
 class IssueCollectorMixin():
-    _issues:list[Issue] = []
+    _issues:List[Issue] = []
     def __init__(self, **kwargs) -> None:
         self.stage = kwargs.get('stage') if kwargs.get('stage') else 'unknown'
 


### PR DESCRIPTION
This PR has two major components:

# SciCat required fields
There are several required fields in Dataset. Errors ingesting into scicat have been found that result in failed scicat ingestion because some fields are not placed in the h5 file. This PR creates defaults for those required fields as a best-effort ingestion.

# Issue Reporting
In the ingest.ingest_jobs collection, errors and warnings are split out for easier querying of truly failed jobs