### PR TITLE
update pydantic, pyscicat

### DIFF
--- a/Dockerfile-webservice
+++ b/Dockerfile-webservice
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8
 
 
 COPY ./requirements.txt /tmp/

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pandas==2.1.1
 passlib==1.7.4
 Pillow==10.0.1
 pydantic==2.4.2
-pyscicat @ git+https://github.com/dylanmcreynolds/pyscicat/tree/small_fixes@new_scicat
+pyscicat @ git+https://github.com/dylanmcreynolds/pyscicat@small_fixes
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-fastapi==0.103.2
-h5py==3.9.0
-numpy==1.26.0
-pandas==2.1.1
-passlib==1.7.4
-Pillow==10.0.1
-pydantic==2.4.2
+fastapi
+h5py
+numpy
+pandas
+passlib
+Pillow
 pyscicat @ git+https://github.com/dylanmcreynolds/pyscicat@small_fixes
-pytz==2023.3.post1
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
-fastapi
-h5py>=3
-numpy
-pandas
-passlib
-Pillow
-pydantic
-pyscicat==0.2.6
-pytz
-suitcase-jsonl
-tzlocal
-zmq
+fastapi==0.103.2
+h5py==3.9.0
+numpy==1.26.0
+pandas==2.1.1
+passlib==1.7.4
+Pillow==10.0.1
+pydantic==2.4.2
+pyscicat @ git+https://github.com/dylanmcreynolds/pyscicat/tree/small_fixes@new_scicat
+pytz==2023.3.post1

--- a/splash_ingest/ingestors/scicat_utils.py
+++ b/splash_ingest/ingestors/scicat_utils.py
@@ -47,7 +47,7 @@ def calculate_access_controls(username, beamline, proposal) -> Dict:
 
 
 def build_search_terms(sample_name):
-    """exctract search terms from sample name to provide something pleasing to search on"""
+    """extract search terms from sample name to provide something pleasing to search on"""
     terms = re.split("[^a-zA-Z0-9]", sample_name)
     description = [term.lower() for term in terms if len(term) > 0]
     return " ".join(description)

--- a/splash_ingest/server/api.py
+++ b/splash_ingest/server/api.py
@@ -101,7 +101,7 @@ class CreateJobRequest(BaseModel):
 
 class CreateJobResponse(BaseModel):
     message: str = Field(description="return message")
-    job_id: Optional[str] = Field(description="uid of newly created job, if created")
+    job_id: Optional[str] = Field(None, description="uid of newly created job, if created")
 
 
 @app.post(

--- a/splash_ingest/server/model.py
+++ b/splash_ingest/server/model.py
@@ -30,9 +30,9 @@ class JobStatus(str, Enum):
 class StatusItem(BaseModel):
     time: datetime
     status: JobStatus
-    log: Optional[str]
+    log: Optional[str] = None
     submitter: str
-    issues: Optional[List[Issue]]
+    issues: Optional[List[Issue]] = None
 
 
 class Job(BaseModel):
@@ -43,9 +43,9 @@ class Job(BaseModel):
     document_path: str
     status: JobStatus = None
     mapping_id: Optional[str] = None
-    submitter: Optional[str]
+    submitter: Optional[str] = None
     status_history: Optional[List[StatusItem]] = []
-    ingest_types: Optional[List[IngestType]]
+    ingest_types: Optional[List[IngestType]] = None
 
 
 class Entity(BaseModel):

--- a/splash_ingest/tests/test_ingest_832tomo.py
+++ b/splash_ingest/tests/test_ingest_832tomo.py
@@ -1,0 +1,8 @@
+from splash_ingest.ingestors import ingest_tomo832
+
+
+
+def test_clean_email():
+    assert ingest_tomo832.clean_email(" 'slartibartfast@magrathea.gov' ") == "slartibartfast@magrathea.gov"
+    assert ingest_tomo832.clean_email("slartibartfast@magrathea.gov") == "slartibartfast@magrathea.gov"
+    assert ingest_tomo832.clean_email(None) == None


### PR DESCRIPTION
The new Scicat backend requires some changes to pyscicat which force some changes to this library.

- Might as well do the migration from pydantic 1.x to 2.x at this point.
- pyscicat changes a lot, and its api changes. Unfortunately, this PR is really urgent and can't wait for approval of [this pyscicat PR](https://github.com/SciCatProject/pyscicat/pull/49) so I'm committing the temporary sin of pinning to a github branch in requirements.txt